### PR TITLE
PathExtension: Get full path only when web/request

### DIFF
--- a/src/twigextensions/PathingVariablesExtension.php
+++ b/src/twigextensions/PathingVariablesExtension.php
@@ -22,7 +22,10 @@ class PathingVariablesExtension extends Twig_Extension implements Twig_Extension
      */
     public function getPathSegments($offset = 0, $length = null)
     {
-        $segments = array_filter(explode('/', Craft::$app->request->getFullPath()));
+        $request = Craft::$app->getRequest();
+        $path = $request->getIsConsoleRequest() ? '' : $request->getFullPath();
+        
+        $segments = array_filter(explode('/', $path));
         $segments = array_slice($segments, $offset, $length);
 
         return array_map(


### PR DESCRIPTION
When trying to generate a template from a console command(for emails in my case) the PathingExtension tries to do Craft::$app->getRequest()->getFullPath() on console\request when it is assuming that request will be web\request.

To fix this I just check if the request is a console request, and if it is then just return an empty string. Otherwise $request->getFullPath().